### PR TITLE
Changes to RunCommand to make running tests on Linux more effective

### DIFF
--- a/tool/src/massive/munit/command/RunCommand.hx
+++ b/tool/src/massive/munit/command/RunCommand.hx
@@ -328,7 +328,7 @@ class RunCommand extends MUnitCommand
     {
         var errors:Array<String> = new Array();
 
-        FileSys.setCwd(console.originalDir.nativePath);
+        FileSys.setCwd(console.dir.nativePath);
         var serverExitCode:Int = 0;
 
         tmpDir = File.current.resolveDirectory("tmp");
@@ -490,17 +490,25 @@ class RunCommand extends MUnitCommand
         var targetLocation:String  = HTTPClient.DEFAULT_SERVER_URL + "/tmp/runner/" + file.fileName;
         var parameters:Array<String> = [];
 
+        // See http://www.dwheeler.com/essays/open-files-urls.html
         if (FileSys.isWindows)
         {
             parameters.push("start");
             if (browser != null)
                 parameters.push(browser);
         }
-        else
+        else if (FileSys.isMac)
         {
             parameters.push("open");
             if (browser != null)
                 parameters.push("-a " + browser);
+        }
+        else if (FileSys.isLinux)
+        {
+            if (browser != null)
+                parameters.push(browser);
+            else 
+                parameters.push("xdg-open");
         }
 
         parameters.push(targetLocation);


### PR DESCRIPTION
This pull request is dependent on this one in MassiveLib:
https://github.com/massiveinteractive/MassiveLib/pull/2

I've made only two small changes
- Change "tmp" directory to be created in local folder, not haxelib folder.  This fixes a permissions issue on linux (see https://github.com/massiveinteractive/MassiveUnit/issues/18)
- Change the launchFile() method to support linux browser launches.  By default they use "xdg-open", unless "browser" is specified in the run command, in which case, use that browser and pass the URL as the first parameter.  This should give the user their default browser for most modern linux distributions.
