### PR TITLE
fix a verify error on as3 test runner

### DIFF
--- a/core/src/massive/munit/ITestResultClient.hx
+++ b/core/src/massive/munit/ITestResultClient.hx
@@ -43,7 +43,8 @@ interface ITestResultClient
 	/**
 	 * Handler which if present, should be called when the client has completed its processing of the results.
 	 */
-	var completionHandler(get_completeHandler, set_completeHandler):ITestResultClient -> Void;
+	function getCompletionHandler():ITestResultClient -> Void ;
+	function setCompletionHandler(value:ITestResultClient -> Void): Void;
 	
 	/**
 	 * The unique identifier for the client.

--- a/core/src/massive/munit/TestRunner.hx
+++ b/core/src/massive/munit/TestRunner.hx
@@ -157,7 +157,7 @@ class TestRunner implements IAsyncDelegateObserver
     {
         for (client in clients) if (client == resultClient) return;
 
-        resultClient.completionHandler = clientCompletionHandler;
+        resultClient.setCompletionHandler(clientCompletionHandler);
         clients.push(resultClient);
     }
 

--- a/core/src/massive/munit/client/AbstractTestResultClient.hx
+++ b/core/src/massive/munit/client/AbstractTestResultClient.hx
@@ -45,14 +45,14 @@ class AbstractTestResultClient implements IAdvancedTestResultClient, implements 
 	/**
 	 * Handler which if present, is called when the client has completed generating its results.
 	 */
-	public var completionHandler(get_completeHandler, set_completeHandler):ITestResultClient -> Void;
-	function get_completeHandler():ITestResultClient -> Void 
+	private var completionHandler:ITestResultClient -> Void;
+	public function getCompletionHandler():ITestResultClient -> Void 
 	{
 		return completionHandler;
 	}
-	function set_completeHandler(value:ITestResultClient -> Void):ITestResultClient -> Void
+	public function setCompletionHandler(value:ITestResultClient -> Void): Void
 	{
-		return completionHandler = value;
+		completionHandler = value;
 	}
 
 	/*

--- a/core/src/massive/munit/client/HTTPClient.hx
+++ b/core/src/massive/munit/client/HTTPClient.hx
@@ -69,14 +69,14 @@ class HTTPClient implements IAdvancedTestResultClient
 	 * Handler which if present, is called when the client has completed sending the test results to the specificied url. 
 	 * This will be called once an HTTP response has been recieved.
 	 */
-	public var completionHandler(get_completeHandler, set_completeHandler):ITestResultClient -> Void;
-	private function get_completeHandler():ITestResultClient -> Void 
+	private var completionHandler:ITestResultClient -> Void;
+	public function getCompletionHandler():ITestResultClient -> Void 
 	{
 		return completionHandler;
 	}
-	private function set_completeHandler(value:ITestResultClient -> Void):ITestResultClient -> Void
+	public function setCompletionHandler(value:ITestResultClient -> Void): Void
 	{
-		return completionHandler = value;
+		completionHandler = value;
 	}
 
 	private var client:ITestResultClient;

--- a/core/src/massive/munit/client/JUnitReportClient.hx
+++ b/core/src/massive/munit/client/JUnitReportClient.hx
@@ -53,14 +53,14 @@ class JUnitReportClient implements IAdvancedTestResultClient
 	/**
 	 * Handler which if present, is called when the client has completed generating its results.
 	 */
-	public var completionHandler(get_completeHandler, set_completeHandler):ITestResultClient -> Void;
-	private function get_completeHandler():ITestResultClient -> Void 
+	private var completionHandler:ITestResultClient -> Void;
+	public function getCompletionHandler():ITestResultClient -> Void 
 	{
 		return completionHandler;
 	}
-	private function set_completeHandler(value:ITestResultClient -> Void):ITestResultClient -> Void
+	public function setCompletionHandler(value:ITestResultClient -> Void): Void
 	{
-		return completionHandler = value;
+		completionHandler = value;
 	}
 
 	/**


### PR DESCRIPTION
when I execute the Example Test, both the as2_test.swf and js test works fine in the browser (tested on firefox and chrome, windows 7) but the as3_test.swf can not be loaded as it throw an verify error :
"VerifyError: Error #1122: Interface method massive.munit::ITestResultClient/set_completionHandler() has illegal method body."

I am not sure what the cause of this (I am running haxe 2.0.9) but I could fix it by not using property getter and setter and using getter and setter function for completionHandler. If you can put it in a next release of munit that would be great.

Thanks for your great work on munit and mlib!

wighawag
