### PR TITLE
Added configuration options to tweak the coverage report generated during the tests

### DIFF
--- a/tool/src/massive/munit/Config.hx
+++ b/tool/src/massive/munit/Config.hx
@@ -53,6 +53,8 @@ class Config
 	
 	public var targetTypes:Array<TargetType>;
 
+	public var coveragePackages:Array<String>;
+	public var coverageIgnoredClasses:Array<String>;
 	
 	public function new(dir:File, currentVersion:String):Void
 	{
@@ -112,6 +114,8 @@ class Config
 						classPaths.push(File.create(path, dir, true));
 					}
 				}
+				case "coveragePackages": coveragePackages = value != "null" ? value.split(",") : null;
+				case "coverageIgnoredClasses": coverageIgnoredClasses = value != "null" ? value.split(",") : null;
 			}
 		}
 	}
@@ -130,10 +134,12 @@ class Config
 
 		resources = null;
 		templates = null;
-		
+
+		coveragePackages = null;
+		coverageIgnoredClasses = null;
 	}
 	
-	public function createDefault(?src:File=null, ?bin:File=null, ?report:File=null, ?hxml:File=null, ?classPaths:Array<File>=null, ?resources:File=null, ?templates:File=null):Void
+	public function createDefault(?src:File=null, ?bin:File=null, ?report:File=null, ?hxml:File=null, ?classPaths:Array<File>=null, ?resources:File=null, ?templates:File=null, ?coveragePackages:Array<String>=null, ?coverageIgnoredClasses:Array<String>=null):Void
 	{
 		this.src = src != null ? src : dir.resolveDirectory("test", true);
 		this.bin = bin != null ? bin : dir.resolveDirectory("bin", true);
@@ -143,6 +149,8 @@ class Config
 		this.resources = resources != null ? resources : null;
 		this.templates = templates != null ? templates : null;
 		this.configVersion = currentVersion;
+		this.coveragePackages = coveragePackages != null ? coveragePackages : null;
+		this.coverageIgnoredClasses = coverageIgnoredClasses != null ? coverageIgnoredClasses : null;
 
 		save();
 	}
@@ -208,8 +216,18 @@ class Config
 		save();
 	}
 
+	public function updateCoveragePackages(coveragePackages:Array<String>):Void
+	{
+		this.coveragePackages = coveragePackages;
+		save();
+	}
 
-	
+	public function updateCoverageIgnoredClasses(coverageIgnoredClasses:Array<String>):Void
+	{
+		this.coverageIgnoredClasses = coverageIgnoredClasses;
+		save();
+	}
+
 	public function toString():String
 	{
 		var str:String = "";
@@ -253,6 +271,14 @@ class Config
 		{
 			str += "templates=" + dir.getRelativePath(templates) + "\n";	
 		}
+		if(coveragePackages != null)
+		{
+			str += "coveragePackages=" + coveragePackages.join(",") + "\n";
+		}
+		if(coverageIgnoredClasses != null)
+		{
+			str += "coverageIgnoredClasses=" + coverageIgnoredClasses.join(",") + "\n";
+		}
 		
 		return str;
 	}
@@ -272,6 +298,8 @@ class Config
 	classPaths=::classPaths::
 	resources=::resources::
 	templates=::templates::
+	coveragePackages=::coveragePackages::
+	coverageIgnoredClasses=::coverageIgnoredClasses::
 	*/
 }
 

--- a/tool/src/massive/munit/command/ConfigCommand.hx
+++ b/tool/src/massive/munit/command/ConfigCommand.hx
@@ -59,6 +59,9 @@ class ConfigCommand extends MUnitCommand
 	var resources:File;
 	var templates:File;
 
+	var coveragePackages:Array<String>;
+	var coverageIgnoredClasses:Array<String>;
+
 	public function new():Void
 	{
 		super();
@@ -112,7 +115,7 @@ class ConfigCommand extends MUnitCommand
 
 		if(!config.exists)
 		{
-			config.createDefault(src, bin, report, hxml,classPaths,resources,templates);
+			config.createDefault(src, bin, report, hxml,classPaths,resources,templates,coveragePackages,coverageIgnoredClasses);
 		}
 		else
 		{
@@ -123,6 +126,8 @@ class ConfigCommand extends MUnitCommand
 			if(hxml != null) config.updateHxml(hxml);
 			if(resources != null) config.updateResources(resources);
 			if(templates != null) config.updateTemplates(templates);
+			if(coveragePackages != null) config.updateCoveragePackages(coveragePackages);
+			if(coverageIgnoredClasses != null) config.updateCoverageIgnoredClasses(coverageIgnoredClasses);
 		}
 	}
 
@@ -159,6 +164,8 @@ class ConfigCommand extends MUnitCommand
 		if(console.getOption("classPaths") != null) return true;
 		if(console.getOption("resources") != null) return true;
 		if(console.getOption("templates") != null) return true;
+		if(console.getOption("coveragePackages") != null) return true;
+		if(console.getOption("coverageIgnoredClasses") != null) return true;
 		return false;
 	}
 	
@@ -172,7 +179,10 @@ class ConfigCommand extends MUnitCommand
 
 		var resourcesArg = console.getOption("resources");
 		var templatesArg = console.getOption("templates");
-		
+
+		var coveragePackagesArg = console.getOption("coveragePackages");
+		var coverageIgnoredClassesArg = console.getOption("coverageIgnoredClasses");
+
 		src = convertToDirectory(srcArg, DEFAULT_SRC, "src");
 		bin = convertToDirectory(binArg, DEFAULT_BIN, "build");
 		report = convertToDirectory(reportArg, DEFAULT_REPORT, "report");
@@ -182,6 +192,8 @@ class ConfigCommand extends MUnitCommand
 		resources = convertToDirectory(resourcesArg, null, "resources");
 		templates = convertToDirectory(templatesArg, null, "templates");
 
+		coveragePackages = convertToStringList(coveragePackagesArg, null, "coveragePackages");
+		coverageIgnoredClasses = convertToStringList(coverageIgnoredClassesArg, null, "coverageIgnoredClasses");
 	}
 
 
@@ -241,6 +253,17 @@ class ConfigCommand extends MUnitCommand
 			templates = convertToDirectory(arg, null, "templates");
 		}
 
+		if(config.coveragePackages == null)
+		{
+			var arg = console.getNextArg("coverage packages (optional, defaults to '" + null + "')");
+			coveragePackages = convertToStringList(arg, null, "coveragePackages");
+		}
+
+		if(config.coverageIgnoredClasses == null)
+		{
+			var arg = console.getNextArg("coverage ignored classes (optional, defaults to '" + null + "')");
+			coverageIgnoredClasses = convertToStringList(arg, null, "coverageIgnoredClasses");
+		}
 	}
 
 	function setDefaultValuesForMissingProperties()
@@ -288,6 +311,8 @@ class ConfigCommand extends MUnitCommand
 		classPaths = tempConfig.classPaths.concat([]);
 		resources = tempConfig.resources;
 		templates = tempConfig.templates;
+		coveragePackages = tempConfig.coveragePackages;
+		coverageIgnoredClasses = tempConfig.coverageIgnoredClasses;
 	}
 
 
@@ -359,5 +384,16 @@ class ConfigCommand extends MUnitCommand
 		}
 
 		return files;
+	}
+
+	function convertToStringList(arg:String, defaultValue:String, label:String):Array<String>
+	{
+		if(arg == null) arg = defaultValue;
+		
+		var strings = arg != null ? arg.split(",") : [];
+		
+		if(strings == null) error("invalid strings list: " + strings);
+		
+		return strings;
 	}
 }

--- a/tool/src/massive/munit/command/TestCommand.hx
+++ b/tool/src/massive/munit/command/TestCommand.hx
@@ -297,7 +297,9 @@ class TestCommand extends MUnitCommand
 				
 				target.hxml += "-D MCOVER\n";
 
-				target.hxml += "--macro m.cover.MCover.coverage([''],['" + clsPaths.join("','") + "'])\n";	
+				var coverPackages = config.coveragePackages != null ? config.coveragePackages.join("','") : "";
+				var coverIgnoredClasses = config.coverageIgnoredClasses != null ? config.coverageIgnoredClasses.join("','") : "";
+				target.hxml += "--macro m.cover.MCover.coverage(['" + coverPackages + "'],['" + clsPaths.join("','") + "'],['" + coverIgnoredClasses + "'])\n";	
 			}
 			
 			if(target.type == TargetType.as2 || target.type == TargetType.as3)


### PR DESCRIPTION
This push request adds options to the .munit configuration files (and to `haxelib run munit config` as well) to tweak the settings given to the MCover macro call.

There is two settings: `coveragePackages` and `coverageIgnoredClasses`.

It is useful to test large project and get meaningful coverage reports. Regarding code style, I've tried to stick to what existed as much as I could. Please keep me posted if you need something adjusted.
