### PR TITLE
Fixing the issue where the Timer is not exposed correctly in the js target when using --js-modern

### DIFF
--- a/core/src/massive/munit/util/Timer.hx
+++ b/core/src/massive/munit/util/Timer.hx
@@ -68,6 +68,7 @@ import cpp.vm.Thread;
 	#end
 #end
 
+@:expose('massive.munit.util.Timer')
 class Timer 
 {
 	#if (php)


### PR DESCRIPTION
Using the expose annotation to make sure that Timer is available on the global scope.
