### PR TITLE
Added assertions for enum values.

### DIFF
--- a/core/src/massive/munit/Assert.hx
+++ b/core/src/massive/munit/Assert.hx
@@ -137,7 +137,31 @@ class Assert
 		assertionCount++;
 		if (Std.is(value, type)) fail("Value [" + value + "] was of type: " + Type.getClassName(type));
 	}
-	
+
+	/**
+	* Assert that a value is of a particular EnumValue
+	*
+	* @param	value				value expected to be of a given type
+	* @param	type				type the value should be
+	*/
+	public static function isEnum(value: Dynamic, type:EnumValue):Void
+	{
+		assertionCount++;
+		if (!Type.enumEq(value, type)) fail("Value [" + value + "] was not of type: " + type);
+	}
+
+	/**
+	* Assert that a value is of a particular EnumValue
+	*
+	* @param	value				value expected to not be of a given type
+	* @param	type				type the value should not be
+	*/
+	public static function isNotEnum(value:Dynamic, type:EnumValue):Void
+	{
+		assertionCount++;
+		if (Type.enumEq(value, type)) fail("Value [" + value + "] was of type: " + type);
+	}
+
 	/**
 	 * Assert that two values are equal.
 	 *  


### PR DESCRIPTION
Hi there!

We have added some assertions for enum values. That's to assert that a given value is (or is not) of certain enum value.

I've run the tests and they _seem_ to pass, but I'm having big trouble running munit sometimes due to that HTTP post bug I think, the neko server hangs a A LOT (at least on Linux).

Let us know what you think.

Cheers!

Juan
