### PR TITLE
Leaner Debug Test Runs

### DIFF
--- a/src/massive/munit/TestRunner.hx
+++ b/src/massive/munit/TestRunner.hx
@@ -276,7 +276,8 @@ class TestRunner implements IAsyncDelegateObserver
         {
             if(Std.is(c, IAdvancedTestResultClient))
             {
-                cast(c, IAdvancedTestResultClient).setCurrentTestClass(activeHelper.className);
+                if(activeHelper.hasNext())
+                    cast(c, IAdvancedTestResultClient).setCurrentTestClass(activeHelper.className);
             }
         }
         for (testCaseData in activeHelper)

--- a/test/massive/munit/DebuglessTestClassStub.hx
+++ b/test/massive/munit/DebuglessTestClassStub.hx
@@ -1,0 +1,36 @@
+/**************************************** ****************************************
+ * Copyright 2010 Massive Interactive. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MASSIVE INTERACTIVE ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSIVE INTERACTIVE OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Massive Interactive.
+ */
+
+package massive.munit;
+class DebuglessTestClassStub {
+
+    public function new() {}
+
+    @Test
+    public function isNotExploding():Void {}
+}

--- a/test/massive/munit/DebuglessTestSuiteStub.hx
+++ b/test/massive/munit/DebuglessTestSuiteStub.hx
@@ -1,0 +1,37 @@
+/**************************************** ****************************************
+ * Copyright 2010 Massive Interactive. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MASSIVE INTERACTIVE ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSIVE INTERACTIVE OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Massive Interactive.
+ */
+
+package massive.munit;
+class DebuglessTestSuiteStub extends massive.munit.TestSuite
+{
+    public function new()
+    {
+        super();
+        add(DebuglessTestClassStub);
+    }
+}

--- a/test/massive/munit/TestRunnerTest.hx
+++ b/test/massive/munit/TestRunnerTest.hx
@@ -113,6 +113,20 @@ class TestRunnerTest
     }
 
     @AsyncTest
+    public function noDebugTestsDuringDebugShouldNotRun(factory:AsyncFactory):Void
+    {
+        var suites = new Array<Class<massive.munit.TestSuite>>();
+
+        suites.push(DebuglessTestSuiteStub);
+        runner.completionHandler = factory.createHandler(this, debugCompletetionHandler, 5000);
+        runner.debug(suites);
+    }
+
+    private function debugCompletetionHandler(isSuccessful:Bool):Void {
+        Assert.areEqual(0, client.testClasses.length);
+    }
+
+    @AsyncTest
     public function testAsyncAssertionTests(factory:AsyncFactory):Void
     {
         var suites = new Array<Class<massive.munit.TestSuite>>();


### PR DESCRIPTION
Test classes without any debug tests are no longer included in debug test runs. This eliminates the need to to vertically scroll while doing debug tests in projects with massive numbers of test classes.
