### PR TITLE
Exiting with 1 when the test wasn't successful

### DIFF
--- a/tool/template/test-main.mtt
+++ b/tool/template/test-main.mtt
@@ -51,7 +51,7 @@ class TestMain
 			#elseif js
 				js.Lib.eval("testResult(" + successful + ");");
 			#elseif sys
-				Sys.exit(0);
+				Sys.exit(successful ? 0 : 1);
 			#end
 		}
 		// if run from outside browser can get error which we can ignore


### PR DESCRIPTION
The TestMain class can be used for native target as well, in which cases the `Sys.exit(0)` call ignores the state of the tests. Returning `0` or `1` depending on the success of the tests allows for a better integration with build systems.
