### PR TITLE
Fix RunCommand when there are spaces in paths for Neko and CPP targets.

### DIFF
--- a/tool/src/massive/munit/command/RunCommand.hx
+++ b/tool/src/massive/munit/command/RunCommand.hx
@@ -646,7 +646,7 @@ class RunCommand extends MUnitTargetCommandBase
 
 		FileSys.setCwd(config.dir.nativePath);
   
-		var exitCode = runCommand("neko " + reportRunnerFile.nativePath);
+		var exitCode = runCommand('neko "${reportRunnerFile.nativePath}"');
 
 		FileSys.setCwd(console.originalDir.nativePath);
 		
@@ -664,7 +664,7 @@ class RunCommand extends MUnitTargetCommandBase
 
 		FileSys.setCwd(config.dir.nativePath);
   
-		var exitCode = runCommand(file.nativePath);
+		var exitCode = runProgram(file.nativePath, []);
 
 		FileSys.setCwd(console.originalDir.nativePath);
 		
@@ -681,6 +681,11 @@ class RunCommand extends MUnitTargetCommandBase
 		var args = command.split(" ");
 		var name = args.shift();
 
+    return runProgram(name, args);
+  }
+
+  function runProgram(name:String, args:Array<String>)
+  {
 		var process = new Process(name, args);
 
 		try
@@ -714,7 +719,7 @@ class RunCommand extends MUnitTargetCommandBase
 		if (exitCode > 0 || stfErrString.length > 0)
 		{
 			if(error != null) error += "\n\t";
-			Sys.println("Error running '" + command + "'\n\t" + error);
+			Sys.println("Error running '" + name + "'\n\t" + error);
 		}
 
 		return exitCode;


### PR DESCRIPTION
If 'haxelib run munit test' is ran from a directory whose full path contains spaces (such as "C:\Users\Zachary Murray\nqhx"), MUnit fails to run for CPP and Neko targets due to RunCommand not correctly handling the paths.