### PR TITLE
added optional msg parameter for assertion tests to provide additional

### DIFF
--- a/src/massive/munit/Assert.hx
+++ b/src/massive/munit/Assert.hx
@@ -46,6 +46,7 @@ class Assert
 	 * Assert that a value is true.
 	 *  
 	 * @param	value				value expected to be true
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if value is not true
 	 */ 
 	public static function isTrue(value:Bool, ?msg:String, ?info:PosInfos):Void
@@ -58,6 +59,7 @@ class Assert
 	 * Assert that a value is false.
 	 *  
 	 * @param	value				value expected to be false
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if value is not false
 	 */ 
 	public static function isFalse(value:Bool, ?msg:String, ?info:PosInfos):Void
@@ -70,6 +72,7 @@ class Assert
 	 * Assert that a value is null.
 	 *  
 	 * @param	value				value expected to be null
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if value is not null
 	 */ 
 	public static function isNull(value:Dynamic, ?msg:String, ?info:PosInfos):Void
@@ -82,6 +85,7 @@ class Assert
 	 * Assert that a value is not null.
 	 *  
 	 * @param	value				value expected not to be null
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if value is null
 	 */ 
 	public static function isNotNull(value:Dynamic, ?msg:String, ?info:PosInfos):Void
@@ -94,6 +98,7 @@ class Assert
 	 * Assert that a value is Math.NaN.
 	 *  
 	 * @param	value				value expected to be Math.NaN
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if value is not Math.NaN
 	 */ 
 	public static function isNaN(value:Float, ?msg:String, ?info:PosInfos):Void
@@ -106,6 +111,7 @@ class Assert
 	 * Assert that a value is not Math.NaN.
 	 *  
 	 * @param	value				value expected not to be Math.NaN
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if value is Math.NaN
 	 */
 	public static function isNotNaN(value:Float, ?msg:String, ?info:PosInfos):Void
@@ -119,6 +125,8 @@ class Assert
 	 * 
 	 * @param	value				value expected to be of a given type
 	 * @param	type				type the value should be
+	 * @param	msg					An optional message to be prefixed on the failure description
+	 * @throws	AssertionException	if value is Math.NaN
 	 */
 	public static function isType(value:Dynamic, type:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
@@ -131,6 +139,8 @@ class Assert
 	 * 
 	 * @param	value				value expected to not be of a given type
 	 * @param	type				type the value should not be
+	 * @param	msg					An optional message to be prefixed on the failure description
+	 * @throws	AssertionException	if value is Math.NaN
 	 */
 	public static function isNotType(value:Dynamic, type:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
@@ -146,6 +156,7 @@ class Assert
 	 *  
 	 * @param	expected			expected value
 	 * @param	actual				actual value
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if expected is not equal to the actual value
 	 */
 	public static function areEqual(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
@@ -172,6 +183,7 @@ class Assert
 	 *  
 	 * @param	expected			expected value
 	 * @param	actual				actual value
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if expected is equal to the actual value
 	 */
 	public static function areNotEqual(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
@@ -195,6 +207,7 @@ class Assert
 	 *  
 	 * @param	expected			expected value
 	 * @param	actual				actual value
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if expected is not the same as the actual value
 	 */
 	public static function areSame(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
@@ -208,6 +221,7 @@ class Assert
 	 *  
 	 * @param	expected			expected value
 	 * @param	actual				actual value
+	 * @param	msg					An optional message to be prefixed on the failure description
 	 * @throws	AssertionException	if expected is the same as the actual value
 	 */
 	public static function areNotSame(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
@@ -219,7 +233,7 @@ class Assert
 	/**
 	  * Force an assertion failure.
 	  *  
-	  * @param	msg				message describing the assertion which failed
+	  * @param	msg					message describing the assertion which failed
 	  * @throws	AssertionException	thrown automatically
 	  */	
 	public static function fail(msg:String, ?info:PosInfos):Void
@@ -231,14 +245,14 @@ class Assert
 	  * Force an assertion failure.
 	  *  
 	  * @param	prefix				additional infomation about the assertion
-	  * @param	msg				message describing the assertion which failed
+	  * @param	msg					message describing the assertion which failed
 	  * @throws	AssertionException	thrown automatically
 	  */	
 	private static function failPrefix(prefix:String, msg:String, ?info:PosInfos):Void
 	{
 		if (prefix != null)
 		{
-			msg = '$prefix - $msg';
+			msg = prefix + " - " + msg;
 		}
 		fail(msg, info);
 	}

--- a/src/massive/munit/Assert.hx
+++ b/src/massive/munit/Assert.hx
@@ -48,10 +48,10 @@ class Assert
 	 * @param	value				value expected to be true
 	 * @throws	AssertionException	if value is not true
 	 */ 
-	public static function isTrue(value:Bool, ?info:PosInfos):Void
+	public static function isTrue(value:Bool, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (value != true) fail("Expected TRUE but was [" + value + "]", info);
+		if (value != true) failPrefix(msg, "Expected TRUE but was [" + value + "]", info);
 	}
 	
 	/**
@@ -60,10 +60,10 @@ class Assert
 	 * @param	value				value expected to be false
 	 * @throws	AssertionException	if value is not false
 	 */ 
-	public static function isFalse(value:Bool, ?info:PosInfos):Void
+	public static function isFalse(value:Bool, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (value != false) fail("Expected FALSE but was [" + value + "]", info);
+		if (value != false) failPrefix(msg, "Expected FALSE but was [" + value + "]", info);
 	}
 	
 	/**
@@ -72,10 +72,10 @@ class Assert
 	 * @param	value				value expected to be null
 	 * @throws	AssertionException	if value is not null
 	 */ 
-	public static function isNull(value:Dynamic, ?info:PosInfos):Void
+	public static function isNull(value:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (value != null) fail("Value [" + value + "] was not NULL", info);
+		if (value != null) failPrefix(msg, "Value [" + value + "] was not NULL", info);
 	}
 	
 	/**
@@ -84,10 +84,10 @@ class Assert
 	 * @param	value				value expected not to be null
 	 * @throws	AssertionException	if value is null
 	 */ 
-	public static function isNotNull(value:Dynamic, ?info:PosInfos):Void
+	public static function isNotNull(value:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (value == null) fail("Value [" + value + "] was NULL", info);
+		if (value == null) failPrefix(msg, "Value [" + value + "] was NULL", info);
 	}
 	
 	/**
@@ -96,10 +96,10 @@ class Assert
 	 * @param	value				value expected to be Math.NaN
 	 * @throws	AssertionException	if value is not Math.NaN
 	 */ 
-	public static function isNaN(value:Float, ?info:PosInfos):Void
+	public static function isNaN(value:Float, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (!Math.isNaN(value)) fail("Value [" + value + "]  was not NaN", info);		
+		if (!Math.isNaN(value)) failPrefix(msg, "Value [" + value + "]  was not NaN", info);		
 	}
 
 	/**
@@ -108,10 +108,10 @@ class Assert
 	 * @param	value				value expected not to be Math.NaN
 	 * @throws	AssertionException	if value is Math.NaN
 	 */
-	public static function isNotNaN(value:Float, ?info:PosInfos):Void
+	public static function isNotNaN(value:Float, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (Math.isNaN(value)) fail("Value [" + value + "] was NaN", info);		
+		if (Math.isNaN(value)) failPrefix(msg, "Value [" + value + "] was NaN", info);		
 	}
 	
 	/**
@@ -120,10 +120,10 @@ class Assert
 	 * @param	value				value expected to be of a given type
 	 * @param	type				type the value should be
 	 */
-	public static function isType(value:Dynamic, type:Dynamic, ?info:PosInfos):Void
+	public static function isType(value:Dynamic, type:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (!Std.is(value, type)) fail("Value [" + value + "] was not of type: " + Type.getClassName(type), info);
+		if (!Std.is(value, type)) failPrefix(msg, "Value [" + value + "] was not of type: " + Type.getClassName(type), info);
 	}
 	
 	/**
@@ -132,10 +132,10 @@ class Assert
 	 * @param	value				value expected to not be of a given type
 	 * @param	type				type the value should not be
 	 */
-	public static function isNotType(value:Dynamic, type:Dynamic, ?info:PosInfos):Void
+	public static function isNotType(value:Dynamic, type:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (Std.is(value, type)) fail("Value [" + value + "] was of type: " + Type.getClassName(type), info);
+		if (Std.is(value, type)) failPrefix(msg, "Value [" + value + "] was of type: " + Type.getClassName(type), info);
 	}
 	
 	/**
@@ -148,7 +148,7 @@ class Assert
 	 * @param	actual				actual value
 	 * @throws	AssertionException	if expected is not equal to the actual value
 	 */
-	public static function areEqual(expected:Dynamic, actual:Dynamic, ?info:PosInfos):Void
+	public static function areEqual(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
 		var equal = switch (Type.typeof(expected))
@@ -161,7 +161,7 @@ class Assert
 			
 			default: expected == actual;
 		}		
-		if (!equal) fail("Value [" + actual +"] was not equal to expected value [" + expected + "]", info);
+		if (!equal) failPrefix(msg, "Value [" + actual +"] was not equal to expected value [" + expected + "]", info);
 	}
 	
 	/**
@@ -174,7 +174,7 @@ class Assert
 	 * @param	actual				actual value
 	 * @throws	AssertionException	if expected is equal to the actual value
 	 */
-	public static function areNotEqual(expected:Dynamic, actual:Dynamic, ?info:PosInfos):Void
+	public static function areNotEqual(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
 		var equal = switch (Type.typeof(expected))
@@ -187,7 +187,7 @@ class Assert
 			default: expected == actual;
 		}
 
-		if (equal) fail("Value [" + actual +"] was equal to value [" + expected + "]", info);
+		if (equal) failPrefix(msg, "Value [" + actual +"] was equal to value [" + expected + "]", info);
 	}
 
 	/**
@@ -197,10 +197,10 @@ class Assert
 	 * @param	actual				actual value
 	 * @throws	AssertionException	if expected is not the same as the actual value
 	 */
-	public static function areSame(expected:Dynamic, actual:Dynamic, ?info:PosInfos):Void
+	public static function areSame(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (expected != actual) fail("Value [" + actual +"] was not the same as expected value [" + expected + "]", info);
+		if (expected != actual) failPrefix(msg, "Value [" + actual +"] was not the same as expected value [" + expected + "]", info);
 	}
 
 	/**
@@ -210,10 +210,10 @@ class Assert
 	 * @param	actual				actual value
 	 * @throws	AssertionException	if expected is the same as the actual value
 	 */
-	public static function areNotSame(expected:Dynamic, actual:Dynamic, ?info:PosInfos):Void
+	public static function areNotSame(expected:Dynamic, actual:Dynamic, ?msg:String, ?info:PosInfos):Void
 	{
 		assertionCount++;
-		if (expected == actual) fail("Value [" + actual +"] was the same as expected value [" + expected + "]", info);
+		if (expected == actual) failPrefix(msg, "Value [" + actual +"] was the same as expected value [" + expected + "]", info);
 	}
 
 	/**
@@ -225,5 +225,21 @@ class Assert
 	public static function fail(msg:String, ?info:PosInfos):Void
 	{
 		throw new AssertionException(msg, info);
+	}
+
+	/**
+	  * Force an assertion failure.
+	  *  
+	  * @param	prefix				additional infomation about the assertion
+	  * @param	msg				message describing the assertion which failed
+	  * @throws	AssertionException	thrown automatically
+	  */	
+	private static function failPrefix(prefix:String, msg:String, ?info:PosInfos):Void
+	{
+		if (prefix != null)
+		{
+			msg = '$prefix - $msg';
+		}
+		fail(msg, info);
 	}
 }

--- a/test/massive/munit/AssertTest.hx
+++ b/test/massive/munit/AssertTest.hx
@@ -35,6 +35,8 @@ import massive.munit.Assert;
  */
 class AssertTest 
 {
+	private static var PREFIX : String = "this is a test prefix";
+
 	public function new() 
 	{
 		
@@ -50,6 +52,22 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testIsTruePrefix():Void
+	{
+		Assert.isTrue(true, PREFIX);
+		try 
+		{
+			Assert.isTrue(false, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -71,6 +89,22 @@ class AssertTest
 	}
 	
 	@Test
+	public function testIsFalsePrefix():Void
+	{
+		Assert.isFalse(false, PREFIX);
+		try 
+		{
+			Assert.isFalse(true, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
 	public function testIsNull():Void
 	{
 		Assert.isNull(null);
@@ -80,6 +114,22 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
+	public function testIsNullPrefix():Void
+	{
+		Assert.isNull(null, PREFIX);
+		try 
+		{
+			Assert.isNull({}, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -101,6 +151,22 @@ class AssertTest
 	}
 	
 	@Test
+	public function testIsNotNullPrefix():Void
+	{
+		Assert.isNotNull({}, PREFIX);
+		try 
+		{
+			Assert.isNotNull(null, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
 	public function testIsNaN():Void
 	{
 		Assert.isNaN(Math.NaN);
@@ -110,6 +176,22 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
+	public function testIsNaNPrefix():Void
+	{
+		Assert.isNaN(Math.NaN, PREFIX);
+		try 
+		{
+			Assert.isNaN(1, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -131,6 +213,22 @@ class AssertTest
 	}
 	
 	@Test
+	public function testIsNotNaNPrefix():Void
+	{
+		Assert.isNotNaN(1, PREFIX);
+		try 
+		{
+			Assert.isNotNaN(Math.NaN, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
 	public function testIsType():Void
 	{
 		Assert.isType(1, Int);
@@ -140,6 +238,22 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
+	public function testIsTypePrefix():Void
+	{
+		Assert.isType(1, Int, PREFIX);
+		try 
+		{
+			Assert.isType(1, String, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -161,6 +275,22 @@ class AssertTest
 	}
 	
 	@Test
+	public function testIsNotTypePrefix():Void
+	{
+		Assert.isNotType(1, String, PREFIX);
+		try 
+		{
+			Assert.isNotType(1, Int, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
 	public function testAreEqualString():Void
 	{
 		Assert.areEqual("yoyo", "yoyo");
@@ -170,6 +300,22 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
+	public function testAreEqualStringPrefix():Void
+	{
+		Assert.areEqual("yoyo", "yoyo", PREFIX);
+		try 
+		{
+			Assert.areEqual("", "yoyo", PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -192,6 +338,23 @@ class AssertTest
 	}
 	
 	@Test
+	public function testAreEqualObjectPrefix():Void
+	{
+		var obj:Dynamic = { };
+		Assert.areEqual(obj, obj, PREFIX);
+		try 
+		{
+			Assert.areEqual({ }, obj, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
 	public function testAreEqualNumber():Void
 	{
 		Assert.areEqual(1, 1);
@@ -201,6 +364,22 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
+	public function testAreEqualNumberPrefix():Void
+	{
+		Assert.areEqual(1, 1, PREFIX);
+		try 
+		{
+			Assert.areEqual(1, 2, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -222,6 +401,22 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreEqualEnumPrefix():Void
+	{
+		Assert.areEqual(ValueA, ValueA, PREFIX);
+		try
+		{
+			Assert.areEqual(ValueA, ValueB, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreEqualEnumWithParam():Void
 	{
 		Assert.areEqual(ValueC("foo"), ValueC("foo"));
@@ -231,6 +426,22 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
+	public function testAreEqualEnumWithParamPrefix():Void
+	{
+		Assert.areEqual(ValueC("foo"), ValueC("foo"), PREFIX);
+		try
+		{
+			Assert.areEqual(ValueC("foo"), ValueC("bar"), PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -252,6 +463,22 @@ class AssertTest
 	}
 	
 	@Test
+	public function testAreNotEqualStringPrefix():Void
+	{
+		Assert.areNotEqual("", "yoyo", PREFIX);
+		try 
+		{
+			Assert.areNotEqual("yoyo", "yoyo", PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+	
+	@Test
 	public function testAreNotEqualObject():Void
 	{
 		var obj:Dynamic = { };
@@ -262,6 +489,23 @@ class AssertTest
 		}
 		catch (e:AssertionException) 
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreNotEqualObjectPrefix():Void
+	{
+		var obj:Dynamic = { };
+		Assert.areNotEqual({}, obj, PREFIX);
+		try 
+		{
+			Assert.areNotEqual(obj, obj, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -283,6 +527,22 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreNotEqualNumberPrefix():Void
+	{
+		Assert.areNotEqual(1, 2, PREFIX);
+		try 
+		{
+			Assert.areNotEqual(1, 1, PREFIX);
+		}
+		catch (e:AssertionException) 
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreNotEqualEnum():Void
 	{
 		Assert.areNotEqual(ValueA, ValueB);
@@ -292,6 +552,22 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreNotEqualEnumPrefix():Void
+	{
+		Assert.areNotEqual(ValueA, ValueB, PREFIX);
+		try
+		{
+			Assert.areNotEqual(ValueA, ValueA, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -312,6 +588,23 @@ class AssertTest
 		Assert.fail("Invalid assertion not captured");
 	}
 
+	@Test
+	public function testAreNotEqualEnumWithParamPrefix():Void
+	{
+		Assert.areNotEqual(ValueC("foo"), ValueC("bar"), PREFIX);
+		try
+		{
+			Assert.areNotEqual(ValueC("foo"), ValueC("foo"), PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreSameString():Void
 	{
 		Assert.areSame("yoyo", "yoyo");
@@ -321,6 +614,22 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreSameStringPrefix():Void
+	{
+		Assert.areSame("yoyo", "yoyo", PREFIX);
+		try
+		{
+			Assert.areEqual("", "yoyo", PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -343,6 +652,23 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreSameObjectPrefix():Void
+	{
+		var obj:Dynamic = {};
+		Assert.areSame(obj, obj, PREFIX);
+		try
+		{
+			Assert.areSame({}, obj, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreSameNumber():Void
 	{
 		Assert.areSame(1, 1);
@@ -358,6 +684,22 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreSameNumberPrefix():Void
+	{
+		Assert.areSame(1, 1, PREFIX);
+		try
+		{
+			Assert.areSame(1, 2, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreSameEnum():Void
 	{
 		Assert.areSame(ValueA, ValueA);
@@ -367,6 +709,22 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreSameEnumPrefix():Void
+	{
+		Assert.areSame(ValueA, ValueA, PREFIX);
+		try
+		{
+			Assert.areSame(ValueA, ValueB, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -389,6 +747,23 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreSameEnumWithParamPrefix():Void
+	{
+		var e = ValueC("foo");
+		Assert.areSame(e, e, PREFIX);
+		try
+		{
+			Assert.areSame(e, ValueC("foo"), PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreNotSameString():Void
 	{
 		Assert.areNotSame("", "yoyo");
@@ -398,6 +773,22 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreNotSameStringPrefix():Void
+	{
+		Assert.areNotSame("", "yoyo", PREFIX);
+		try
+		{
+			Assert.areNotSame("yoyo", "yoyo", PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -420,6 +811,23 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreNotSameObjectPrefix():Void
+	{
+		var obj:Dynamic = {};
+		Assert.areNotSame({}, obj, PREFIX);
+		try
+		{
+			Assert.areNotSame(obj, obj, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreNotSameNumber():Void
 	{
 		Assert.areNotSame(1, 2);
@@ -429,6 +837,22 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreNotSameNumberPrefix():Void
+	{
+		Assert.areNotSame(1, 2, PREFIX);
+		try
+		{
+			Assert.areNotSame(1, 1, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");
@@ -450,6 +874,22 @@ class AssertTest
 	}
 
 	@Test
+	public function testAreNotSameEnumPrefix():Void
+	{
+		Assert.areNotSame(ValueA, ValueB, PREFIX);
+		try
+		{
+			Assert.areNotSame(ValueA, ValueA, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreNotSameEnumWithParam():Void
 	{
 		Assert.areNotSame(ValueC("foo"), ValueC("foo"));
@@ -460,6 +900,23 @@ class AssertTest
 		}
 		catch (e:AssertionException)
 		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testAreNotSameEnumWithParamPrefix():Void
+	{
+		Assert.areNotSame(ValueC("foo"), ValueC("foo"), PREFIX);
+		try
+		{
+			var e = ValueC("foo");
+			Assert.areNotSame(e, e, PREFIX);
+		}
+		catch (e:AssertionException)
+		{
+			Assert.isTrue(StringTools.startsWith(e.message, PREFIX + " - "));
 			return;
 		}
 		Assert.fail("Invalid assertion not captured");


### PR DESCRIPTION
Hi,

I have added an optional msg parameter to the assertion functions to so developers can give addtional information about which test failed. 
e.g. if you have a test function A that calls a sub-routine B which does the actual asserting, PosInfo only points to the line in B that failed. But you won't know which line in A caused the error. If you pass PosInfo of B to your asserts you will know which line in A caused the failure, but not which specific test in B failed.
With my patch you can pass PosInfo from B and a message parameter to your assert and when it fails you get the line number from A and a prefix message from B telling you exactly where to look.
