### PR TITLE
Large scale suites & CPP traces

### DIFF
--- a/src/massive/munit/TestRunner.hx
+++ b/src/massive/munit/TestRunner.hx
@@ -100,6 +100,8 @@ class TestRunner implements IAsyncDelegateObserver
     public var completionHandler:Bool -> Void;
 
     public var clientCount(get_clientCount, null):Int;
+    public var testSuites:Array<TestSuite>;
+
     private function get_clientCount():Int { return clients.length; }
 
     public var running(default, null):Bool;
@@ -114,7 +116,6 @@ class TestRunner implements IAsyncDelegateObserver
     private var clients:Array<ITestResultClient>;
 
     private var activeHelper:TestClassHelper;
-    private var testSuites:Array<TestSuite>;
 
     private var asyncPending:Bool;
     private var asyncDelegate:AsyncDelegate;
@@ -254,6 +255,7 @@ class TestRunner implements IAsyncDelegateObserver
                     return;
                 }
             }
+            testSuites[i] = null;
         }
 
         if (!asyncPending)

--- a/src/massive/munit/client/RichPrintClient.hx
+++ b/src/massive/munit/client/RichPrintClient.hx
@@ -57,7 +57,9 @@ class RichPrintClient extends PrintClientBase
 		super.init();
 
 		originalTrace = haxe.Log.trace;
+		#if !cpp
 		haxe.Log.trace = customTrace;
+		#end
 
 		external = new ExternalPrintClientJS();
 	}

--- a/test/massive/munit/TestRunnerTest.hx
+++ b/test/massive/munit/TestRunnerTest.hx
@@ -98,6 +98,7 @@ class TestRunnerTest
         Assert.areEqual(0, client.finalErrorCount);
         Assert.areEqual(1, client.testClasses.length);
         Assert.isNull(client.currentTestClass);
+        Assert.isNull(runner.testSuites[0]);
 
         Assert.areEqual("massive.munit.TestClassStub", client.testClasses[client.testClasses.length-1]);
     }


### PR DESCRIPTION
When projects are large enough they test runner will crash. I fixed this by dereferencing already executed test suits.

When null exceptions occur in C++ the test runner fails to catch the exception and the stack trace is lost. I conditionally removed the redirection of haxe.trace to allow for trace debugging.