### PR TITLE
Replace deprecated alert call by new one

### DIFF
--- a/src/massive/munit/client/PrintClient.hx
+++ b/src/massive/munit/client/PrintClient.hx
@@ -27,13 +27,9 @@
 ****/
 
 package massive.munit.client;
-import massive.munit.client.PrintClientBase;
-import massive.munit.AssertionException;
-import massive.munit.ITestResultClient;
-import massive.munit.TestResult;
-import massive.munit.util.MathUtil;
+import js.Browser;
 import massive.haxe.util.ReflectUtil;
-import massive.munit.util.Timer;
+import massive.munit.client.PrintClientBase;
 
 
 /**
@@ -140,7 +136,7 @@ class PrintClient extends PrintClientBase
 		{
 			var positionInfo = ReflectUtil.here();
 			var error:String = "MissingElementException: 'haxe:trace' element not found at " + positionInfo.className + "#" + positionInfo.methodName + "(" + positionInfo.lineNumber + ")";
-			js.Lib.alert(error);
+			Browser.alert(error);
 		}	
 	}
 	#end

--- a/src/massive/munit/client/PrintClientBase.hx
+++ b/src/massive/munit/client/PrintClientBase.hx
@@ -28,12 +28,10 @@
 
 package massive.munit.client;
 
-import massive.munit.AssertionException;
-import massive.munit.ITestResultClient;
+import js.Browser;
+import massive.haxe.util.ReflectUtil;
 import massive.munit.TestResult;
 import massive.munit.util.MathUtil;
-import massive.haxe.util.ReflectUtil;
-import massive.munit.util.Timer;
 
 class PrintClientBase extends AbstractTestResultClient
 {
@@ -346,7 +344,7 @@ class ExternalPrintClientJS implements ExternalPrintClient
 			{
 				var positionInfo = ReflectUtil.here();
 				var error:String = "MissingElementException: 'haxe:trace' element not found at " + positionInfo.className + "#" + positionInfo.methodName + "(" + positionInfo.lineNumber + ")";
-				js.Lib.alert(error);
+				Browser.alert(error);
 			}	
 		#else
 


### PR DESCRIPTION
Lib.alert() is deprecated, use Browser.alert() instead

I also have cleaned dependency
