### PR TITLE
Remove deprecation warning about `Lib.alert()`

### DIFF
--- a/src/massive/munit/client/PrintClient.hx
+++ b/src/massive/munit/client/PrintClient.hx
@@ -140,7 +140,7 @@ class PrintClient extends PrintClientBase
 		{
 			var positionInfo = ReflectUtil.here();
 			var error:String = "MissingElementException: 'haxe:trace' element not found at " + positionInfo.className + "#" + positionInfo.methodName + "(" + positionInfo.lineNumber + ")";
-			js.Lib.alert(error);
+			js.Browser.alert(error);
 		}	
 	}
 	#end

--- a/src/massive/munit/client/PrintClientBase.hx
+++ b/src/massive/munit/client/PrintClientBase.hx
@@ -346,7 +346,7 @@ class ExternalPrintClientJS implements ExternalPrintClient
 			{
 				var positionInfo = ReflectUtil.here();
 				var error:String = "MissingElementException: 'haxe:trace' element not found at " + positionInfo.className + "#" + positionInfo.methodName + "(" + positionInfo.lineNumber + ")";
-				js.Lib.alert(error);
+				js.Browser.alert(error);
 			}	
 		#else
 


### PR DESCRIPTION
`Warning : Lib.alert() is deprecated, use Browser.alert() instead`