### PR TITLE
Removed warnings displayed in console when running test on js platform

### DIFF
--- a/src/massive/munit/client/PrintClient.hx
+++ b/src/massive/munit/client/PrintClient.hx
@@ -140,7 +140,11 @@ class PrintClient extends PrintClientBase
 		{
 			var positionInfo = ReflectUtil.here();
 			var error:String = "MissingElementException: 'haxe:trace' element not found at " + positionInfo.className + "#" + positionInfo.methodName + "(" + positionInfo.lineNumber + ")";
+			#if haxe3
+			js.Browser.alert(error);
+			#else
 			js.Lib.alert(error);
+			#end
 		}	
 	}
 	#end

--- a/src/massive/munit/client/PrintClientBase.hx
+++ b/src/massive/munit/client/PrintClientBase.hx
@@ -346,7 +346,11 @@ class ExternalPrintClientJS implements ExternalPrintClient
 			{
 				var positionInfo = ReflectUtil.here();
 				var error:String = "MissingElementException: 'haxe:trace' element not found at " + positionInfo.className + "#" + positionInfo.methodName + "(" + positionInfo.lineNumber + ")";
+				#if haxe3
+				js.Browser.alert(error);
+				#else
 				js.Lib.alert(error);
+				#end
 			}	
 		#else
 


### PR DESCRIPTION
Hi, I kept having a warning message displayed when running tests for js:

`HaxeWrapper.hx:73: /Users/troll/lib/haxelib/munit/2,1,2/massive/munit/client/PrintClientBase.hx:349: characters 4-16 : Warning : Lib.alert() is deprecated, use Browser.alert() instead`

So I thought I'd make my first PR to fix this! Thanks for this amazing test frameword by the way.