### PR TITLE
Regular expression matcher assertions

### DIFF
--- a/src/massive/munit/Assert.hx
+++ b/src/massive/munit/Assert.hx
@@ -215,7 +215,43 @@ class Assert
 		assertionCount++;
 		if (expected == actual) fail("Value [" + actual +"] was the same as expected value [" + expected + "]", info);
 	}
-    
+
+	/**
+	 * Assert that a string matches a regular expression. The internal state of the given regular expression
+	 * may be modified by this assertion.
+	 *
+	 * @param	string			value expected to match the regular expression
+	 * @param	regex			a regular expression that should match the string value
+	 * @throws	AssertionException	if regex does not match string
+	 */
+	public static function doesMatch(string:String, regexp:EReg, ?info:PosInfos)
+	{
+		assertionCount++;
+
+		var matches:Bool = regexp.match(string);
+		if (matches) return;
+
+		fail("Value [" + string +"] was expected to match [" + regexp + "]", info);
+	}
+
+	/**
+	 * Assert that a string does not match a regular expression. The internal state of the given regular expression
+	 * may be modified by this assertion.
+	 *
+	 * @param	string			value expected to not match the regular expression
+	 * @param	regex			a regular expression that should not match the string value
+	 * @throws	AssertionException	if regex matches string
+	 */
+	public static function doesNotMatch(string:String, regexp:EReg, ?info:PosInfos)
+	{
+		assertionCount++;
+
+		var matches:Bool = regexp.match(string);
+		if (!matches) return;
+
+		fail("Value [" + string +"] was expected to not match [" + regexp + "], and matched at [" + regexp.matchedPos().pos + "]", info);
+	}
+
 	/**
 	 * Assert that an expectation was thrown. Can expect strings and non-strings.
 	 *

--- a/test/massive/munit/AssertTest.hx
+++ b/test/massive/munit/AssertTest.hx
@@ -389,6 +389,22 @@ class AssertTest
 	}
 
 	@Test
+	public function testDoesMatch():Void
+	{
+		Assert.doesMatch("regular_example_45-", ~/^regular_example_\d+\-$/);
+
+		try
+		{
+			Assert.doesMatch("regular_example_45", ~/^regular_\d+$/);
+		}
+		catch (e:AssertionException)
+		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
 	public function testAreNotSameString():Void
 	{
 		Assert.areNotSame("", "yoyo");
@@ -457,6 +473,23 @@ class AssertTest
 		{
 			var e = ValueC("foo");
 			Assert.areNotSame(e, e);
+		}
+		catch (e:AssertionException)
+		{
+			return;
+		}
+		Assert.fail("Invalid assertion not captured");
+	}
+
+	@Test
+	public function testDoesNotMatch():Void
+	{
+		Assert.doesNotMatch("this is a string", ~/^This is a string$/);
+		Assert.doesNotMatch("fff", ~/^\d+$/);
+
+		try
+		{
+			Assert.doesNotMatch("#198c19", ~/^#[0-9a-c]+$/i);
 		}
 		catch (e:AssertionException)
 		{


### PR DESCRIPTION
I though it would be a good idea to add regular expression matchers for strings; something that can be used like this:

````hx
var my_string = MyClass.compute_my_string();
Assert.doesMatch(my_string, ~/\d+\-\d+/);
````

And the negation of it:

````hx
var my_string = MyClass.compute_my_string();
Assert.doesNotMatch(my_string, ~/\d+\-\d+/);
````