### PR TITLE
Fix for build.sh.

### DIFF
--- a/tool/src/massive/munit/command/RunCommand.hx
+++ b/tool/src/massive/munit/command/RunCommand.hx
@@ -662,7 +662,7 @@ class RunCommand extends MUnitTargetCommandBase
 
 		FileSys.setCwd(config.dir.nativePath);
   
-		var exitCode = runCommand('neko "${reportRunnerFile.nativePath}"');
+		var exitCode = runCommand('neko ${reportRunnerFile.nativePath}');
 
 		FileSys.setCwd(console.originalDir.nativePath);
 		


### PR DESCRIPTION
I'm on OSX with haxe 3.4.0. The build.sh script will fail without good output, doing this fixes it. I have not tested wit earlier version of haxe.