### PR TITLE
Fix compile with OpenFL development version

### DIFF
--- a/src/massive/munit/client/HTTPClient.hx
+++ b/src/massive/munit/client/HTTPClient.hx
@@ -327,7 +327,7 @@ class URLRequest
 	#if flash9
 		function internalOnData(event:flash.events.Event) 
 		{
-			onData(event.target.data);
+			onData(cast (event.target, URLRequest).data);
 		}
 
 		function internalOnError(event:flash.events.Event)


### PR DESCRIPTION
A minor change to fix support for newer OpenFL development versions. `event.target` has to be cast on all targets (except Flash) in order to work properly with Haxe getters or setters, and we're thinking of using `Any` instead so that all targets (including Flash) need to be cast to access children