### PR TITLE
remove custom setter/getter functions

### DIFF
--- a/src/massive/munit/TestResult.hx
+++ b/src/massive/munit/TestResult.hx
@@ -92,7 +92,7 @@ class TestResult
 	 */
 	public var error:Dynamic;
 
-	public var type(get_type, null):TestResultType;
+	public var type(get, null):TestResultType;
 	
 	/**
 	 * Class constructor.


### PR DESCRIPTION
A recent commit to Haxe4 has removed support for custom property accessor functions.