### PR TITLE
Resolve a minor cast issue on Flash HTTP client

### DIFF
--- a/src/massive/munit/client/HTTPClient.hx
+++ b/src/massive/munit/client/HTTPClient.hx
@@ -312,7 +312,7 @@ class URLRequest
 	#if flash
 	function internalOnData(event:flash.events.Event) 
 	{
-		onData(cast (event.target, URLRequest).data);
+		onData(cast (event.target, flash.net.URLLoader).data);
 	}
 	function internalOnError(event:flash.events.Event)
 	{


### PR DESCRIPTION
One of the objects was typed wrong, and causes a pop-up error dialog each time the Flash HTTPClient runs using a debug version of Flash Player