### PR TITLE
allow using custom TestClassHelpers

### DIFF
--- a/src/massive/munit/TestRunner.hx
+++ b/src/massive/munit/TestRunner.hx
@@ -213,7 +213,7 @@ class TestRunner implements IAsyncDelegateObserver
             {
                 if (activeHelper == null || activeHelper.type != testClass)
                 {
-                    activeHelper = new TestClassHelper(testClass, isDebug);
+                    activeHelper = createTestClassHelper(testClass);
                     tryCallMethod(activeHelper.test, activeHelper.beforeClass, emptyParams);
                 }
                 executeTestCases();
@@ -391,4 +391,6 @@ class TestRunner implements IAsyncDelegateObserver
         if(Reflect.compareMethods(func, TestClassHelper.nullFunc)) return null;
         return Reflect.callMethod(o, func, args);
     }
+
+    function createTestClassHelper(testClass:Class<Dynamic>):TestClassHelper return new TestClassHelper(testClass, isDebug);
 }


### PR DESCRIPTION
instantiating `activeHelper` through a separate function allows a `TestRunner` child class to create a custom `TestClassHelper` that supports e.g. test filtering (see https://github.com/vshaxe/haxe-test-adapter and https://github.com/vshaxe/haxe-test-adapter/tree/master/src/unittesthelper/munit)