### PR TITLE
Timer: fix undefined massive.munit.util error in JS

### DIFF
--- a/src/massive/munit/util/Timer.hx
+++ b/src/massive/munit/util/Timer.hx
@@ -83,9 +83,10 @@ class Timer
 			var me = this;
 			id = untyped __global__["flash.utils.setInterval"](function() { me.run(); },time_ms);
 		#elseif js
-			id = arr.length;
-			arr[id] = this;
-			timerId = untyped window.setInterval("massive.munit.util.Timer.arr[" + id + "].run();", time_ms);
+			var localID = arr.length;
+			id = localID;
+			arr[localID] = this;
+			timerId = untyped window.setInterval(function() { massive.munit.util.Timer.arr[localID].run(); }, time_ms);
 		#elseif (neko || cpp || java)
 			var me = this;
 			runThread = Thread.create(me.runLoop.bind(time_ms));


### PR DESCRIPTION
The following code in the constructor for `massive.munit.util.Timer` causes runtime errors in JS:

```hx
id = arr.length;
arr[id] = this;
timerId = untyped window.setInterval("massive.munit.util.Timer.arr[" + id + "].run();", time_ms);
```

Error in Firefox:

> TypeError: massive.munit.util is undefined

Error in Chrome: 

> TypeError: Cannot read property 'Timer' of undefined

This error makes it impossible for me to write async tests.

I should note that my project uses Haxe 4 and OpenFL, so I need to use the `haxelib run openfl build html5` command to properly compile my tests.

My *.hxml* looks like this:

```hxml
-lib openfl
-lib actuate
-lib munit
-cp ../src
-cp src

--each

--next

-cmd haxelib run openfl build html5
-js build/html5/bin/TestMain.js
```