### PR TITLE
Change `equal` comparison order for efficiency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,12 @@
 - Added support for `lua` target
 - Added `Assert.isEmpty(anObject:StringOrIterable, ?message)`. Assert that a `String` or `Iterable` is empty.
 - Added `Assert.isNotEmpty(anObject:StringOrIterable, ?message)`. Assert that a `String` or `Iterable` is not empty.
-- Starting with version 2.3.5, special provision has been made for comparing collections(`Array`, `IMap` or `Bytes`). Two collections will be treated as equal by `Assert.areEqual` if they are the same `length` and each of the corresponding elements is equal.
-- Starting with version 2.3.5, special provision has been made for comparing dates. Two dates will be treated as equal by `Assert.areEqual` if their `getTime()` values are equal.
-- Starting with version 2.3.5, special provision has been made for comparing types. Two types will be treated as equal by `Assert.areEqual` if their classname are equal.
-- Starting with version 2.3.5, special provision has been made for comparing custom structures. Two structures will be treated as equal by `Assert.areEqual` if each of the corresponding fields is equal.
+- [BREAKING CHANGE] `Assert.equals/Assert.areEqual` comparison logic has changed:
+
+	- Comparing collections (`Array`, `IMap` or `Bytes`): two collections will be treated as equal if they are the same `length` and each of the corresponding elements is equal.
+	- Comparing Date objects: two dates will be treated as equal if their `getTime()` values are equal.
+	- Comparing types: two types will be treated as equal if their classname are equal.
+	- Comparing custom structures: two structures will be treated as equal if each of the corresponding fields is equal.
 
 ## 2.3.4
 

--- a/src/massive/munit/Assert.hx
+++ b/src/massive/munit/Assert.hx
@@ -333,7 +333,8 @@ class Assert
 			case TEnum(_): Type.enumEq(a, b);
 			case TFunction: Reflect.compareMethods(a, b);
 			case TClass(_):
-				if(Std.is(a, String) && Std.is(b, String)) return a == b;
+				if(a == b) return true;
+				if(Std.is(a, String) && Std.is(b, String)) return false; // previous comparison failed
 				if(Std.is(a, Array) && Std.is(b, Array)) {
 					var a:Array<Dynamic> = cast a;
 					var b:Array<Dynamic> = cast b;
@@ -368,7 +369,6 @@ class Assert
 					var b = cast(b, Date).getTime();
 					return a == b;
 				}
-				if(a == b) return true;
 				// custom class
 				var afields = Type.getInstanceFields(Type.getClass(a));
 				var bfields = Type.getInstanceFields(Type.getClass(b));


### PR DESCRIPTION
Test reference equality first

cc @SlavaRa 