### PR TITLE
fix Std.is deprecation warnings

### DIFF
--- a/src/massive/munit/Assert.hx
+++ b/src/massive/munit/Assert.hx
@@ -33,6 +33,12 @@ import haxe.PosInfos;
 import haxe.extern.EitherType; 
 import haxe.io.Bytes;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 #if python
 using StringTools;
 #end
@@ -151,7 +157,7 @@ class Assert
 	public static function isType(value:Dynamic, type:Dynamic, ?message:String, ?info:PosInfos)
 	{
 		assertionCount++;
-		if(Std.is(value, type)) return;
+		if(isOfType(value, type)) return;
 		if(message == null) message = "Value [" + value + "] was not of type: " + Type.getClassName(type);
 		fail(message, info);
 	}
@@ -166,7 +172,7 @@ class Assert
 	public static function isNotType(value:Dynamic, type:Dynamic, ?message:String, ?info:PosInfos)
 	{
 		assertionCount++;
-		if(!Std.is(value, type)) return;
+		if(!isOfType(value, type)) return;
 		if(message == null) message = "Value [" + value + "] was of type: " + Type.getClassName(type);
 		fail(message, info);
 	}
@@ -290,7 +296,7 @@ class Assert
 		}
 		catch (e:Dynamic)
 		{
-			if(Std.is(e, expectedType)) return e;
+			if(isOfType(e, expectedType)) return e;
 			Assert.fail('Expected exception of type ${Type.getClassName(expectedType)} but got ${Type.getClassName(Type.getClass(e))}: ${e}');
 		}
 		return null;
@@ -334,8 +340,8 @@ class Assert
 			case TFunction: Reflect.compareMethods(a, b);
 			case TClass(_):
 				if(a == b) return true;
-				if(Std.is(a, String) && Std.is(b, String)) return false; // previous comparison failed
-				if(Std.is(a, Array) && Std.is(b, Array)) {
+				if(isOfType(a, String) && isOfType(b, String)) return false; // previous comparison failed
+				if(isOfType(a, Array) && isOfType(b, Array)) {
 					var a:Array<Dynamic> = cast a;
 					var b:Array<Dynamic> = cast b;
 					if(a.length != b.length) return false;
@@ -344,7 +350,7 @@ class Assert
 					}
 					return true;
 				}
-				if(Std.is(a, Bytes) && Std.is(b, Bytes)) {
+				if(isOfType(a, Bytes) && isOfType(b, Bytes)) {
 					var a = cast(a, Bytes);
 					var b = cast(b, Bytes);
 					if(a.length != b.length) return false;
@@ -353,7 +359,7 @@ class Assert
 					}
 					return true;
 				}
-				if(Std.is(a, IMap) && Std.is(b, IMap)) {
+				if(isOfType(a, IMap) && isOfType(b, IMap)) {
 					var a:IMap<Dynamic, Dynamic> = cast a;
 					var b:IMap<Dynamic, Dynamic> = cast b;
 					var akeys = [for(it in a.keys()) it];
@@ -364,7 +370,7 @@ class Assert
 					}
 					return true;
 				}
-				if(Std.is(a, Date) && Std.is(b, Date)) {
+				if(isOfType(a, Date) && isOfType(b, Date)) {
 					var a = cast(a, Date).getTime();
 					var b = cast(b, Date).getTime();
 					return a == b;
@@ -381,7 +387,7 @@ class Assert
 				}
 				return true;
 			case TObject:
-				if(Std.is(a, Class) && Std.is(b, Class)) {
+				if(isOfType(a, Class) && isOfType(b, Class)) {
 					var a = Type.getClassName(a);
 					var b = Type.getClassName(b);
 					return a == b;
@@ -417,9 +423,9 @@ class Assert
 	}
 	
 	static inline function empty(anObject:StringOrIterable):Bool {
-		if(Std.is(anObject, String)) {
+		if(isOfType(anObject, String)) {
 			return (anObject:String).length == 0;
-		} else if(Std.is(anObject, Array)) {
+		} else if(isOfType(anObject, Array)) {
 			var a:Array<Dynamic> = cast anObject;
 			return a.length == 0;
 		} else {

--- a/src/massive/munit/TestRunner.hx
+++ b/src/massive/munit/TestRunner.hx
@@ -47,6 +47,12 @@ import cpp.vm.Thread;
 import java.vm.Thread;
 #end
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 /**
  * Runner used to execute one or more suites of unit tests.
  *
@@ -235,7 +241,7 @@ class TestRunner implements IAsyncDelegateObserver
             var time:Float = Timer.stamp() - startTime;
             for (client in clients)
             {
-                if(Std.is(client, IAdvancedTestResultClient))
+                if(isOfType(client, IAdvancedTestResultClient))
                 {
                     var cl:IAdvancedTestResultClient = cast client;
                     cl.setCurrentTestClass(null);
@@ -249,7 +255,7 @@ class TestRunner implements IAsyncDelegateObserver
     {
         for(c in clients)
         {
-            if(Std.is(c, IAdvancedTestResultClient) && activeHelper.hasNext())
+            if(isOfType(c, IAdvancedTestResultClient) && activeHelper.hasNext())
 			{
 				var cl:IAdvancedTestResultClient = cast c;
 				cl.setCurrentTestClass(activeHelper.className);
@@ -310,11 +316,11 @@ class TestRunner implements IAsyncDelegateObserver
             }
 
 			#if hamcrest
-			if (Std.is(e, org.hamcrest.AssertionException))
+			if (isOfType(e, org.hamcrest.AssertionException))
 				e = new AssertionException(e.message, e.info);
 			#end
 
-            if (Std.is(e, AssertionException))
+            if (isOfType(e, AssertionException))
             {
                 result.executionTime = Timer.stamp() - testStartTime;
                 result.failure = e;
@@ -325,7 +331,7 @@ class TestRunner implements IAsyncDelegateObserver
             else
             {
                 result.executionTime = Timer.stamp() - testStartTime;
-                if (!Std.is(e, MUnitException))
+                if (!isOfType(e, MUnitException))
                     e = new UnhandledException(e, result.location);
 
                 result.error = e;

--- a/src/massive/munit/client/HTTPClient.hx
+++ b/src/massive/munit/client/HTTPClient.hx
@@ -34,6 +34,12 @@ import haxe.ds.StringMap;
 import massive.munit.ITestResultClient;
 import massive.munit.TestResult;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 /**
  * Decorates other ITestResultClient's, adding behavior to post test results to a specified url.
  * 
@@ -107,7 +113,7 @@ class HTTPClient implements IAdvancedTestResultClient
 	 */
 	public function setCurrentTestClass(className:String)
 	{
-		if(Std.is(client, IAdvancedTestResultClient))
+		if(isOfType(client, IAdvancedTestResultClient))
 		{
 			cast(client, IAdvancedTestResultClient).setCurrentTestClass(className);
 		}

--- a/src/massive/munit/client/PrintClientBase.hx
+++ b/src/massive/munit/client/PrintClientBase.hx
@@ -32,6 +32,12 @@ import massive.munit.ITestResultClient.CoverageResult;
 import massive.munit.TestResult;
 import massive.munit.util.MathUtil;
 
+#if (haxe_ver >= 4.2)
+import Std.isOfType;
+#else
+import Std.is as isOfType;
+#end
+
 class PrintClientBase extends AbstractTestResultClient
 {
 	/**
@@ -406,7 +412,7 @@ class ExternalPrintClientJS implements ExternalPrintClient
 		#end
 		
 		var a:Array<Dynamic> = [];
-		if(Std.is(args, Array)) a = a.concat(cast(args, Array<Dynamic>));
+		if(isOfType(args, Array)) a = a.concat(cast(args, Array<Dynamic>));
 		else a.push(args);
 		var jsCode = convertToJavaScript(method, a);
 		#if js


### PR DESCRIPTION
This will prevent Std.is deprecation warnings on haxe 4.2+ without causing errors when running on earlier versions