### PR TITLE
Haxe 4.3.1 compatibility

### DIFF
--- a/src/massive/munit/TestResult.hx
+++ b/src/massive/munit/TestResult.hx
@@ -110,8 +110,7 @@ class TestResult
 
 }
 
-@:enum
-abstract TestResultType(String) to String
+enum abstract TestResultType(String) to String
 {
 	var UNKNOWN = "UNKNOWN";
 	var PASS = "PASS";

--- a/src/massive/munit/TestResult.hx
+++ b/src/massive/munit/TestResult.hx
@@ -110,7 +110,8 @@ class TestResult
 
 }
 
-enum abstract TestResultType(String) to String
+#if haxe4 enum #else @:enum #end
+abstract TestResultType(String) to String
 {
 	var UNKNOWN = "UNKNOWN";
 	var PASS = "PASS";

--- a/src/massive/munit/client/HTTPClient.hx
+++ b/src/massive/munit/client/HTTPClient.hx
@@ -47,21 +47,21 @@ import Std.is as isOfType;
  */
 class HTTPClient implements IAdvancedTestResultClient
 {
-	@:extern public inline static var DEFAULT_SERVER_URL:String = "http://localhost:2000";
+	extern public inline static var DEFAULT_SERVER_URL:String = "http://localhost:2000";
 	/**
 	 * Default id of this client.
 	 */
-	@:extern public inline static var DEFAULT_ID:String = "HTTPClient";
+	extern public inline static var DEFAULT_ID:String = "HTTPClient";
 
 	/**
 	 * HTTP header key. Contains id of client the HTTPClient is decorating.
 	 */
-	@:extern public inline static var CLIENT_HEADER_KEY:String = "munit-clientId";
+	extern public inline static var CLIENT_HEADER_KEY:String = "munit-clientId";
 
 	/**
 	 * HTTP header key. Contains id of platform being tests (flash,js,neko,cpp,php).
 	 */
-	@:extern public inline static var PLATFORM_HEADER_KEY:String = "munit-platformId";
+	extern public inline static var PLATFORM_HEADER_KEY:String = "munit-platformId";
 
 	/* Global sequental (FIFO) http request queue */
 	private static var queue:Array<URLRequest> = [];

--- a/src/massive/munit/client/HTTPClient.hx
+++ b/src/massive/munit/client/HTTPClient.hx
@@ -47,21 +47,25 @@ import Std.is as isOfType;
  */
 class HTTPClient implements IAdvancedTestResultClient
 {
-	extern public inline static var DEFAULT_SERVER_URL:String = "http://localhost:2000";
+	#if haxe4 extern #else @:extern #end
+	public inline static var DEFAULT_SERVER_URL:String = "http://localhost:2000";
 	/**
 	 * Default id of this client.
 	 */
-	extern public inline static var DEFAULT_ID:String = "HTTPClient";
+	#if haxe4 extern #else @:extern #end
+	public inline static var DEFAULT_ID:String = "HTTPClient";
 
 	/**
 	 * HTTP header key. Contains id of client the HTTPClient is decorating.
 	 */
-	extern public inline static var CLIENT_HEADER_KEY:String = "munit-clientId";
+	#if haxe4 extern #else @:extern #end
+	public inline static var CLIENT_HEADER_KEY:String = "munit-clientId";
 
 	/**
 	 * HTTP header key. Contains id of platform being tests (flash,js,neko,cpp,php).
 	 */
-	extern public inline static var PLATFORM_HEADER_KEY:String = "munit-platformId";
+	#if haxe4 extern #else @:extern #end
+	public inline static var PLATFORM_HEADER_KEY:String = "munit-platformId";
 
 	/* Global sequental (FIFO) http request queue */
 	private static var queue:Array<URLRequest> = [];


### PR DESCRIPTION
This prevents deprecation warnings in haxe 4.3.1, without breaking haxe 3.4.7